### PR TITLE
Create generic.cfg for Acronis True Image 2021

### DIFF
--- a/mbusb.d/acronis.d/generic.cfg
+++ b/mbusb.d/acronis.d/generic.cfg
@@ -1,0 +1,38 @@
+for isofile in $isopath/acronis*.iso; do
+  if [ -e "$isofile" ]; then
+    regexp --set=isoname "$isopath/(.*)" "$isofile"
+    submenu "$isoname ->" "$isofile" {
+      iso_path="$2"
+      loopback loop "$iso_path"
+      #set mbrcrcs=on
+      #set quiet=on
+      #set gfxpayload=800x600x16
+      menuentry "Acronis True Image 2021" {
+        set gfxpayload=1024x768x32,1024x768
+        bootoptions="ramdisk_size=32768 quiet mbrcrcs=on force_modules=usbhid"
+        #linux /Recovery\ Manager/kernel[64].dat $bootoptions
+        #initrd /Recovery\ Manager/ramdisk_merged[64].dat
+        linux (loop)/dat2.dat $bootoptions
+        initrd (loop)/dat3.dat (loop)/dat4.dat
+      }
+      menuentry "Acronis System Report" {
+        set gfxpayload=1024x768x32,1024x768
+        bootoptions="ramdisk_size=32768 quiet mbrcrcs=on force_modules=usbhid product=system_report"
+        linux (loop)/dat6.dat $bootoptions
+        initrd (loop)/dat7.dat (loop)/dat8.dat
+      }
+      menuentry "Acronis True Image 2021 (x64)" {
+        set gfxpayload=1024x768x32,1024x768
+        bootoptions="ramdisk_size=32768 quiet mbrcrcs=on force_modules=usbhid"
+        linux (loop)/dat10.dat $bootoptions
+        initrd (loop)/dat11.dat (loop)/dat12.dat
+      }
+      menuentry "Acronis System Report (x64)" {
+        set gfxpayload=1024x768x32,1024x768
+        bootoptions="ramdisk_size=32768 quiet mbrcrcs=on force_modules=usbhid product=system_report"
+        linux (loop)/dat14.dat $bootoptions
+        initrd (loop)/dat15.dat (loop)/dat16.dat
+      }
+    }
+  fi
+done


### PR DESCRIPTION
I noticed the following equalities between the dat##.dat files (checked with their respective checksums):

dat2 = dat6 = "Recovery Manager"/kernel.dat
dat10 = dat14 = "Recovery Manager"/kernel64.dat
dat3 = dat7 = "Recovery Manager"/ramdisk_merged.dat dat11 = dat15 = "Recovery Manager"/ramdisk_merged64.dat dat4 = dat12
dat8 = dat16

I wonder why Acronis assigns different names to the same things, even if different menu entries...